### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ matrix:
           go: tip
         - os: windows
           go: 1.x
+#Added power jobs
+        - os: linux
+          go: tip
+          arch: ppc64le
+        - os: linux
+          go: tip
+          arch: ppc64le
+          env:
+            - JS=1
 script: bash .travis.sh script
 notifications:
   webhooks: https://coveralls.io/webhook


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.